### PR TITLE
Speed Up FFmpeg

### DIFF
--- a/app/src/main/kotlin/me/rhunk/snapenhance/download/FFMpegProcessor.kt
+++ b/app/src/main/kotlin/me/rhunk/snapenhance/download/FFMpegProcessor.kt
@@ -115,6 +115,7 @@ class FFMpegProcessor(
         // load ffmpeg native sync to avoid native crash
         synchronized(this) { FFmpegKit.listSessions() }
         val globalArguments = ArgumentList().apply {
+            this += "-hwaccel auto" //Use hwaccel If Available
             this += "-y"
             this += "-threads" to ffmpegOptions.threads.get().toString()
         }

--- a/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/DownloaderConfig.kt
+++ b/common/src/main/kotlin/me/rhunk/snapenhance/common/config/impl/DownloaderConfig.kt
@@ -6,7 +6,7 @@ import me.rhunk.snapenhance.common.config.FeatureNotice
 
 class DownloaderConfig : ConfigContainer() {
     inner class FFMpegOptions : ConfigContainer() {
-        val threads = integer("threads", 1)
+        val threads = integer("threads", 4) // Bump Default Value to 4 Tested on Pixel 5 (Qualcomm Snapdragon 765G) Had no lag
         val preset = unique("preset", "ultrafast", "superfast", "veryfast", "faster", "fast", "medium", "slow", "slower", "veryslow") {
             addFlags(ConfigFlag.NO_TRANSLATE)
         }


### PR DESCRIPTION
* Bump default threads to 4 (20-30% CPU Increase when downloading)
+ Add -hwaccel auto flag

Now getting 100-111 FPS Instead of 80-90 FPS on Pixel 5 (Lowest End Device i had to see impact)