### PR TITLE
Various changes to workflow files

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -16,10 +16,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -32,41 +32,32 @@ jobs:
       - name: Build
         run: ./gradlew assembleArmv8Debug
 
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
+
       - name: Sign APK
         id: sign_app
-        uses: tiann/zipalign-sign-android-release@v1.1.4
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: app/build/outputs/apk/armv8/debug/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-          zipAlign: true
         env:
-          BUILD_TOOLS_VERSION: "34.0.0"
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
-      - name: Delete unsigned file
-        run: |
-          cd app/build/outputs/apk/armv8/debug/
-          shopt -s extglob
-          rm -rf !(*-signed*)
-
-      - name: Build Version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@main
-
-      - name: Rename APK file
+      - name: Delete unsigned APK file and rename the signed one
         run: |
-          mv app/build/outputs/apk/armv8/debug/*.apk app/build/outputs/apk/armv8/debug/snapenhance-${{ env.version }}-armv8-${{ steps.version-env.outputs.sha_short }}.apk
+          find app/build/outputs/apk/armv8/debug/ -type f ! -name '*-signed*' -delete
+          mv ${{steps.sign_app.outputs.signedReleaseFile}} app/build/outputs/apk/armv8/debug/snapenhance-${{ env.version }}-armv8-${GITHUB_SHA::7}.apk
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -82,10 +73,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -98,41 +89,32 @@ jobs:
       - name: Build
         run: ./gradlew assembleArmv7Debug
 
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
+
       - name: Sign APK
         id: sign_app
-        uses: tiann/zipalign-sign-android-release@v1.1.4
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: app/build/outputs/apk/armv7/debug/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-          zipAlign: true
         env:
-          BUILD_TOOLS_VERSION: "34.0.0"
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
-      - name: Delete unsigned file
-        run: |
-          cd app/build/outputs/apk/armv7/debug/
-          shopt -s extglob
-          rm -rf !(*-signed*)
-
-      - name: Build Version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@main
-
-      - name: Rename APK file
+      - name: Delete unsigned APK file and rename the signed one
         run: |
-          mv app/build/outputs/apk/armv7/debug/*.apk app/build/outputs/apk/armv7/debug/snapenhance-${{ env.version }}-armv7-${{ steps.version-env.outputs.sha_short }}.apk
+          find app/build/outputs/apk/armv7/debug/ -type f ! -name '*-signed*' -delete
+          mv ${{steps.sign_app.outputs.signedReleaseFile}} app/build/outputs/apk/armv7/debug/snapenhance-${{ env.version }}-armv7-${GITHUB_SHA::7}.apk
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -148,10 +130,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -164,41 +146,32 @@ jobs:
       - name: Build
         run: ./gradlew assembleAllDebug
 
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
+
       - name: Sign APK
         id: sign_app
-        uses: tiann/zipalign-sign-android-release@v1.1.4
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: app/build/outputs/apk/all/debug/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-          zipAlign: true
         env:
-          BUILD_TOOLS_VERSION: "34.0.0"
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
-      - name: Delete unsigned file
-        run: |
-          cd app/build/outputs/apk/all/debug/
-          shopt -s extglob
-          rm -rf !(*-signed*)
-
-      - name: Build Version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@main
-
-      - name: Rename APK files
+      - name: Delete unsigned APK file and rename the signed one
         run: |
-          mv app/build/outputs/apk/all/debug/*.apk app/build/outputs/apk/all/debug/snapenhance-${{ env.version }}-universal-${{ steps.version-env.outputs.sha_short }}.apk
+          find app/build/outputs/apk/all/debug/ -type f ! -name '*-signed*' -delete
+          mv ${{steps.sign_app.outputs.signedReleaseFile}} app/build/outputs/apk/all/debug/snapenhance-${{ env.version }}-universal-${GITHUB_SHA::7}.apk
 
       - name: Upload universal
         uses: actions/upload-artifact@v4
@@ -214,10 +187,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -241,10 +214,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,10 +12,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -28,22 +28,15 @@ jobs:
       - name: Build
         run: ./gradlew assembleArmv8Debug
 
-      - name: Build Version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@main
 
       - name: Rename APK file
         run: |
-          mv app/build/outputs/apk/armv8/debug/*.apk app/build/outputs/apk/armv8/debug/snapenhance-${{ env.version }}-armv8-${{ steps.version-env.outputs.sha_short }}.apk
+          mv app/build/outputs/apk/armv8/debug/*.apk app/build/outputs/apk/armv8/debug/snapenhance-${{ env.version }}-armv8-${GITHUB_SHA::7}.apk
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -59,10 +52,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -75,22 +68,15 @@ jobs:
       - name: Build
         run: ./gradlew assembleArmv7Debug
 
-      - name: Build Version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@main
 
       - name: Rename APK file
         run: |
-          mv app/build/outputs/apk/armv7/debug/*.apk app/build/outputs/apk/armv7/debug/snapenhance-${{ env.version }}-armv7-${{ steps.version-env.outputs.sha_short }}.apk
+          mv app/build/outputs/apk/armv7/debug/*.apk app/build/outputs/apk/armv7/debug/snapenhance-${{ env.version }}-armv7-${GITHUB_SHA::7}.apk
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -106,10 +92,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -122,22 +108,15 @@ jobs:
       - name: Build
         run: ./gradlew assembleAllDebug
 
-      - name: Build Version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
-      - name: Git branch name
-        id: git-branch-name
-        uses: EthanSK/git-branch-name-action@main
-
-      - name: Rename APK files
+      - name: Rename APK file
         run: |
-          mv app/build/outputs/apk/all/debug/*.apk app/build/outputs/apk/all/debug/snapenhance-${{ env.version }}-universal-${{ steps.version-env.outputs.sha_short }}.apk
+          mv app/build/outputs/apk/all/debug/*.apk app/build/outputs/apk/all/debug/snapenhance-${{ env.version }}-universal-${GITHUB_SHA::7}.apk
 
       - name: Upload universal
         uses: actions/upload-artifact@v4
@@ -153,10 +132,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -180,10 +159,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -35,28 +35,28 @@ jobs:
 
       - name: Build
         run: ./gradlew assembleArmv8Release
+
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
         
       - name: Sign APK
         id: sign_app
-        uses: kevin-david/zipalign-sign-android-release@main
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: app/build/outputs/apk/armv8/release/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-
-      - name: Delete unsigned file
-        run: |
-          cd app/build/outputs/apk/armv8/release/
-          shopt -s extglob
-          rm !(*-signed*)
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
       
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: snapenhance-armv8-release
-          path: app/build/outputs/apk/armv8/release/*.apk
+          path: ${{steps.sign_app.outputs.signedReleaseFile}}
           
   job_armv7:
     runs-on: macos-latest
@@ -66,10 +66,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -82,27 +82,27 @@ jobs:
       - name: Build
         run: ./gradlew assembleArmv7Release
 
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
+
       - name: Sign APK
         id: sign_app
-        uses: kevin-david/zipalign-sign-android-release@main
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: app/build/outputs/apk/armv7/release/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-
-      - name: Delete unsigned file
-        run: |
-          cd app/build/outputs/apk/armv7/release/
-          shopt -s extglob
-          rm !(*-signed*)
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: snapenhance-armv7-release
-          path: app/build/outputs/apk/armv7/release/*.apk
+          path: ${{steps.sign_app.outputs.signedReleaseFile}}
 
   job_universal:
     runs-on: macos-latest
@@ -112,10 +112,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -127,28 +127,28 @@ jobs:
 
       - name: Build
         run: ./gradlew assembleAllRelease
-        
+
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
+
       - name: Sign APK
         id: sign_app
-        uses: kevin-david/zipalign-sign-android-release@main
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: app/build/outputs/apk/all/release/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-
-      - name: Delete unsigned file
-        run: |
-          cd app/build/outputs/apk/all/release/
-          shopt -s extglob
-          rm !(*-signed*)
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       - name: Upload universal
         uses: actions/upload-artifact@v4
         with:
           name: snapenhance-universal-release
-          path: app/build/outputs/apk/all/release/*.apk
+          path: ${{steps.sign_app.outputs.signedReleaseFile}}
 
   job_manager:
     runs-on: ubuntu-latest
@@ -158,10 +158,10 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
@@ -171,27 +171,27 @@ jobs:
       - name: Build
         run: ./gradlew manager:assembleRelease
 
+      - name: Determine the latest Build Tools version installed
+        shell: bash
+        run: echo "BUILD_TOOL_VERSION=$(ls "$ANDROID_HOME/build-tools/" | tail -n 1)" >> $GITHUB_ENV
+
       - name: Sign APK
         id: sign_app
-        uses: kevin-david/zipalign-sign-android-release@main
+        uses: SnapEnhance/sign-android-release@master
         with:
           releaseDirectory: manager/build/outputs/apk/release/
           signingKeyBase64: ${{ secrets.JAVA_KEYSTORE_DATA }}
           alias: ${{ secrets.KEY_ALIAS }}
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
-
-      - name: Delete unsigned file
-        run: |
-          cd manager/build/outputs/apk/release/
-          shopt -s extglob
-          rm !(*-signed*)
+        env:
+          BUILD_TOOLS_VERSION: ${{ env.BUILD_TOOL_VERSION }}
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: manager
-          path: manager/build/outputs/apk/release/*.apk
+          path: ${{steps.sign_app.outputs.signedReleaseFile}}
 
   job_release:
     runs-on: ubuntu-latest
@@ -203,24 +203,21 @@ jobs:
         with:
           submodules: 'recursive'
 
-      - name: set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
           cache: gradle
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Generate version
-        run: ./gradlew getVersion
-
-      - name: Set Environment Variables
+      - name: Get current build version
         id: version-env
         run: |
+          ./gradlew getVersion
           echo "version=$(cat app/build/version.txt)" >> $GITHUB_ENV
-          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -229,9 +226,9 @@ jobs:
           merge-multiple: true
 
       - name: Publish APK
-        uses: marvinpinto/action-automatic-releases@latest
+        uses: softprops/action-gh-release@v2
         with:
-          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ inputs.prerelease }}
           files: bins/*.apk
-          automatic_release_tag: v${{ env.version }}
+          tag_name: v${{ env.version }}

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Thanks to everyone involved including the [third-party libraries](https://github
 - [CanerKaraca23](https://github.com/CanerKaraca23)
 - [bocajthomas](https://github.com/bocajthomas)
 - [w451](https://github.com/w451)
+- [sn-o-w](https://github.com/sn-o-w)
 
 ## Donate
 **@rhunk**


### PR DESCRIPTION
The Release CI workflow is currently failing, likely due to the minimum required Android SDK Build-tools version for `macos-latest` GitHub-hosted runners being updated to 33.0.2, while the version used in https://github.com/kevin-david/zipalign-sign-android-release is 32.0.0.

Changes made in this PR include:
- Upgraded Java version from 17 to 21.
- ~~Utilized `kevin-david/zipalign-sign-android-release@main` in both workflows.~~
_(Updated to `noriban/sign-android-release` in both workflows, seems to be more updated recently)_
- ~~Manually enabled zipaligning option of signed files in the Release CI workflow, too.~~
_(Enabled by default in `noriban/sign-android-release`)_
- Automatically determined and utilized the latest installed Build Tools version for APK signing.
- Utilized `${{steps.sign_app.outputs.signedReleaseFile}}` to point to the signed APK files.
- Utilized `${GITHUB_SHA::7}` to obtain the short Git version hash in Debug CI
- Removed the 'Git branch name' step in Debug CI (no longer used, I guess?!)
- Removed the 'Delete unsigned file' step (redundant in Release CI since we can directly upload `${{steps.sign_app.outputs.signedReleaseFile}}`).
- In Debug CI delete unsigned files right before renaming the signed ones.
- In Release CI switch to `softprops/action-gh-release` since `marvinpinto/action-automatic-releases` is no longer maintained.
- ~~Added Dependabot to automatically submit a PR when a new version of an action is published.~~